### PR TITLE
Feature/configurable name converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,4 +165,11 @@ The json-cast filter supports nested fields. To provide multiple fields use `;` 
 * Type: string
 * Importance: high
 * Default: null
-  
+
+``connector.fieldname_converter``
+This fields determine which fieldname converter should be used.
+By default AVRO fieldname converter is used, this means that json field names should respect AVRO specifications (https://avro.apache.org/docs/current/spec.html#names)
+If you need to use non-avro compliant field names please set this parameter to NOP
+* Type: string
+* Importance: high
+* Default: null

--- a/README.md
+++ b/README.md
@@ -166,10 +166,11 @@ The json-cast filter supports nested fields. To provide multiple fields use `;` 
 * Importance: high
 * Default: null
 
-``connector.fieldname_converter``
-This fields determine which fieldname converter should be used.
-By default AVRO fieldname converter is used, this means that json field names should respect AVRO specifications (https://avro.apache.org/docs/current/spec.html#names)
-If you need to use non-avro compliant field names please set this parameter to NOP
+``fieldname_converter``
+Configuring which field name converter should be used (allowed values: `avro` or `nop`).
+By default, the avro field name converter renames the json fields non respecting the avro specifications (https://avro.apache.org/docs/current/spec.html#names) 
+in order to be serialized correctly.
+To disable the field name conversion set this parameter to `nop`.
 * Type: string
-* Importance: high
-* Default: null
+* Importance: medium
+* Default: avro

--- a/src/main/java/com/github/dariobalinzo/ElasticSourceConnectorConfig.java
+++ b/src/main/java/com/github/dariobalinzo/ElasticSourceConnectorConfig.java
@@ -116,11 +116,12 @@ public class ElasticSourceConnectorConfig extends AbstractConfig {
     private static final String FIELDS_JSON_CAST_DOC = "Cast to json string instead of parsing nested objects (e.g. order.qty;order.price;status )";
     private static final String FIELDS_JSON_CAST_DISPLAY = "Cast to json string";
 
-    public static final String CONNECTOR_FIELDNAME_CONVERTER_CONFIG = "connector.fieldname_converter";
-    public static final String CONNECTOR_FIELDNAME_CONVERTER_DOC = "Determine which name converter should be used for document fields: AVRO converter as standard";
-    public static final String CONNECTOR_FIELDNAME_CONVERTER_DISPLAY = "Fields name converter";
+    public static final String CONNECTOR_FIELDNAME_CONVERTER_CONFIG = "fieldname_converter";
+    public static final String CONNECTOR_FIELDNAME_CONVERTER_DOC = "Determine which name converter should be used for document fields: avro converter as standard";
+    public static final String CONNECTOR_FIELDNAME_CONVERTER_DISPLAY = "Fields name converter (avro, nop)";
 
-    public static final String NOP_FIELDNAME_CONVERTER = "NOP";
+    public static final String NOP_FIELDNAME_CONVERTER = "nop";
+    public static final String AVRO_FIELDNAME_CONVERTER = "avro";
 
     public static final ConfigDef CONFIG_DEF = baseConfigDef();
 
@@ -306,8 +307,8 @@ public class ElasticSourceConnectorConfig extends AbstractConfig {
         ).define(
                 CONNECTOR_FIELDNAME_CONVERTER_CONFIG,
                 Type.STRING,
-                null,
-                Importance.HIGH,
+                AVRO_FIELDNAME_CONVERTER,
+                Importance.MEDIUM,
                 CONNECTOR_FIELDNAME_CONVERTER_DOC,
                 CONNECTOR_GROUP,
                 ++orderInGroup,

--- a/src/main/java/com/github/dariobalinzo/ElasticSourceConnectorConfig.java
+++ b/src/main/java/com/github/dariobalinzo/ElasticSourceConnectorConfig.java
@@ -116,11 +116,11 @@ public class ElasticSourceConnectorConfig extends AbstractConfig {
     private static final String FIELDS_JSON_CAST_DOC = "Cast to json string instead of parsing nested objects (e.g. order.qty;order.price;status )";
     private static final String FIELDS_JSON_CAST_DISPLAY = "Cast to json string";
 
-    public static final String CONNECTOR_FIELDNAME_CONVERTER_CONFIG = "fields.name_converter";
+    public static final String CONNECTOR_FIELDNAME_CONVERTER_CONFIG = "connector.fieldname_converter";
     public static final String CONNECTOR_FIELDNAME_CONVERTER_DOC = "Determine which name converter should be used for document fields: AVRO converter as standard";
     public static final String CONNECTOR_FIELDNAME_CONVERTER_DISPLAY = "Fields name converter";
 
-    public static final String NOP_FIELDNAME_CONVERTER = "Nop";
+    public static final String NOP_FIELDNAME_CONVERTER = "NOP";
 
     public static final ConfigDef CONFIG_DEF = baseConfigDef();
 

--- a/src/main/java/com/github/dariobalinzo/ElasticSourceConnectorConfig.java
+++ b/src/main/java/com/github/dariobalinzo/ElasticSourceConnectorConfig.java
@@ -116,8 +116,11 @@ public class ElasticSourceConnectorConfig extends AbstractConfig {
     private static final String FIELDS_JSON_CAST_DOC = "Cast to json string instead of parsing nested objects (e.g. order.qty;order.price;status )";
     private static final String FIELDS_JSON_CAST_DISPLAY = "Cast to json string";
 
-    public static final String AVRO_FIELD_CONVERTER = "Avro";
-    public static final String NOP_FIELD_CONVERTER = "Nop";
+    public static final String CONNECTOR_FIELDNAME_CONVERTER_CONFIG = "fields.name_converter";
+    public static final String CONNECTOR_FIELDNAME_CONVERTER_DOC = "Determine which name converter should be used for document fields: AVRO converter as standard";
+    public static final String CONNECTOR_FIELDNAME_CONVERTER_DISPLAY = "Fields name converter";
+
+    public static final String NOP_FIELDNAME_CONVERTER = "Nop";
 
     public static final ConfigDef CONFIG_DEF = baseConfigDef();
 
@@ -232,7 +235,6 @@ public class ElasticSourceConnectorConfig extends AbstractConfig {
                 Width.MEDIUM,
                 FIELDS_JSON_CAST_DISPLAY
         );
-        ;
     }
 
     private static void addModeOptions(ConfigDef config) {
@@ -301,6 +303,16 @@ public class ElasticSourceConnectorConfig extends AbstractConfig {
                 ++orderInGroup,
                 Width.MEDIUM,
                 TOPIC_PREFIX_DISPLAY
+        ).define(
+                CONNECTOR_FIELDNAME_CONVERTER_CONFIG,
+                Type.STRING,
+                null,
+                Importance.HIGH,
+                CONNECTOR_FIELDNAME_CONVERTER_DOC,
+                CONNECTOR_GROUP,
+                ++orderInGroup,
+                Width.MEDIUM,
+                CONNECTOR_FIELDNAME_CONVERTER_DISPLAY
         );
     }
 

--- a/src/main/java/com/github/dariobalinzo/ElasticSourceConnectorConfig.java
+++ b/src/main/java/com/github/dariobalinzo/ElasticSourceConnectorConfig.java
@@ -116,9 +116,10 @@ public class ElasticSourceConnectorConfig extends AbstractConfig {
     private static final String FIELDS_JSON_CAST_DOC = "Cast to json string instead of parsing nested objects (e.g. order.qty;order.price;status )";
     private static final String FIELDS_JSON_CAST_DISPLAY = "Cast to json string";
 
+    public static final String AVRO_FIELD_CONVERTER = "Avro";
+    public static final String NOP_FIELD_CONVERTER = "Nop";
 
     public static final ConfigDef CONFIG_DEF = baseConfigDef();
-
 
     protected static ConfigDef baseConfigDef() {
         ConfigDef config = new ConfigDef();

--- a/src/main/java/com/github/dariobalinzo/schema/AvroName.java
+++ b/src/main/java/com/github/dariobalinzo/schema/AvroName.java
@@ -16,17 +16,17 @@
 
 package com.github.dariobalinzo.schema;
 
-public class AvroName {
+public class AvroName implements FieldNameConverter {
 
-    public static String from(String elasticName) {
+    public String from(String elasticName) {
         return elasticName == null ? null : filterInvalidCharacters(elasticName);
     }
 
-    public static String from(String prefix, String elasticName) {
+    public String from(String prefix, String elasticName) {
         return elasticName == null ? prefix : prefix + filterInvalidCharacters(elasticName);
     }
 
-    private static String filterInvalidCharacters(String elasticName) {
+    private String filterInvalidCharacters(String elasticName) {
         boolean alphabetic = Character.isLetter(elasticName.charAt(0));
         if (!alphabetic) {
             elasticName = "avro" + elasticName;

--- a/src/main/java/com/github/dariobalinzo/schema/FieldNameConverter.java
+++ b/src/main/java/com/github/dariobalinzo/schema/FieldNameConverter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2018 Dario Balinzo (dariobalinzo@gmail.com)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.github.dariobalinzo.schema;
 
 public interface FieldNameConverter {

--- a/src/main/java/com/github/dariobalinzo/schema/FieldNameConverter.java
+++ b/src/main/java/com/github/dariobalinzo/schema/FieldNameConverter.java
@@ -1,0 +1,9 @@
+package com.github.dariobalinzo.schema;
+
+public interface FieldNameConverter {
+
+    String from(String elasticName);
+
+    String from(String prefix, String elasticName);
+
+}

--- a/src/main/java/com/github/dariobalinzo/schema/NopNameConverter.java
+++ b/src/main/java/com/github/dariobalinzo/schema/NopNameConverter.java
@@ -1,0 +1,13 @@
+package com.github.dariobalinzo.schema;
+
+public class NopNameConverter implements FieldNameConverter {
+
+    public String from(String elasticName) {
+        return elasticName;
+    }
+
+    public String from(String prefix, String elasticName) {
+        return elasticName == null ? prefix : prefix + elasticName;
+    }
+
+}

--- a/src/main/java/com/github/dariobalinzo/schema/NopNameConverter.java
+++ b/src/main/java/com/github/dariobalinzo/schema/NopNameConverter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2018 Dario Balinzo (dariobalinzo@gmail.com)
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.github.dariobalinzo.schema;
 
 public class NopNameConverter implements FieldNameConverter {

--- a/src/main/java/com/github/dariobalinzo/schema/SchemaConverter.java
+++ b/src/main/java/com/github/dariobalinzo/schema/SchemaConverter.java
@@ -30,7 +30,7 @@ import static org.apache.kafka.connect.data.SchemaBuilder.struct;
 
 public class SchemaConverter {
 
-    FieldNameConverter converter;
+    private final FieldNameConverter converter;
 
     public SchemaConverter(FieldNameConverter converter) {
         this.converter = converter;

--- a/src/main/java/com/github/dariobalinzo/task/ElasticSourceTask.java
+++ b/src/main/java/com/github/dariobalinzo/task/ElasticSourceTask.java
@@ -106,15 +106,18 @@ public class ElasticSourceTask extends SourceTask {
     }
 
     private void initConnectorFieldConverter() {
-        String fieldnameConverterConfig = config.getString(ElasticSourceConnectorConfig.CONNECTOR_FIELDNAME_CONVERTER_CONFIG);
-        FieldNameConverter fieldNameConverter = new AvroName();
+        String nameConverterConfig = config.getString(ElasticSourceConnectorConfig.CONNECTOR_FIELDNAME_CONVERTER_CONFIG);
 
-        if (fieldnameConverterConfig != null &&
-            fieldnameConverterConfig.equals(ElasticSourceConnectorConfig.NOP_FIELDNAME_CONVERTER))
-        {
-            fieldNameConverter = new NopNameConverter();
+        FieldNameConverter fieldNameConverter;
+        switch (nameConverterConfig) {
+            case ElasticSourceConnectorConfig.NOP_FIELDNAME_CONVERTER:
+                fieldNameConverter = new NopNameConverter();
+                break;
+            case ElasticSourceConnectorConfig.AVRO_FIELDNAME_CONVERTER:
+            default:
+                fieldNameConverter = new AvroName();
+                break;
         }
-
         this.schemaConverter = new SchemaConverter(fieldNameConverter);
         this.structConverter = new StructConverter(fieldNameConverter);
     }

--- a/src/test/java/com/github/dariobalinzo/TestContainersContext.java
+++ b/src/test/java/com/github/dariobalinzo/TestContainersContext.java
@@ -90,6 +90,8 @@ public class TestContainersContext {
                 .field("fullName", "Test")
                 .field(CURSOR_FIELD, tsStart)
                 .field("age", 10)
+                .field("non-avro-field", "non-avro-field")
+                .field("avroField", "avro-field")
                 .endObject();
 
         IndexRequest indexRequest = new IndexRequest(index);

--- a/src/test/java/com/github/dariobalinzo/schema/AvroNameTest.java
+++ b/src/test/java/com/github/dariobalinzo/schema/AvroNameTest.java
@@ -26,11 +26,12 @@ public class AvroNameTest {
     public void shouldCreateValidAvroNames() {
         //given
         String invalidName = "foo.bar";
+        FieldNameConverter converter = new AvroName();
 
         //when
-        String validName = AvroName.from(invalidName);
-        String validNamePrefix = AvroName.from("prefix", invalidName);
-        String startByNumber = AvroName.from("1invalid");
+        String validName = converter.from(invalidName);
+        String validNamePrefix = converter.from("prefix", invalidName);
+        String startByNumber = converter.from("1invalid");
 
         //then
         Assert.assertEquals("foobar", validName);

--- a/src/test/java/com/github/dariobalinzo/schema/SchemaConverterTest.java
+++ b/src/test/java/com/github/dariobalinzo/schema/SchemaConverterTest.java
@@ -31,8 +31,8 @@ import java.util.*;
 
 public class SchemaConverterTest {
 
-    private final SchemaConverter schemaConverter = new SchemaConverter();
-    private final StructConverter structConverter = new StructConverter();
+    private final SchemaConverter schemaConverter = new SchemaConverter(new AvroName());
+    private final StructConverter structConverter = new StructConverter(new AvroName());
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test

--- a/src/test/java/com/github/dariobalinzo/task/ElasticSourceTaskTest.java
+++ b/src/test/java/com/github/dariobalinzo/task/ElasticSourceTaskTest.java
@@ -150,7 +150,7 @@ public class ElasticSourceTaskTest extends TestContainersContext {
         //when (fetching first page)
         task.start(conf);
         List<SourceRecord> poll1 = task.poll();
-        assertEquals("Struct{fullName=\"Test\",age=10,ts=111}", poll1.get(0).value().toString());
+        assertEquals("Struct{fullName=\"Test\",nonavrofield=non-avro-field,avroField=avro-field,age=10,ts=111}", poll1.get(0).value().toString());
 
         task.stop();
     }

--- a/src/test/java/com/github/dariobalinzo/task/ElasticSourceTaskTest.java
+++ b/src/test/java/com/github/dariobalinzo/task/ElasticSourceTaskTest.java
@@ -155,4 +155,56 @@ public class ElasticSourceTaskTest extends TestContainersContext {
         task.stop();
     }
 
+    @Test
+    public void shouldRunSourceTaskWithAvroNameConverter() throws IOException, InterruptedException {
+        //given
+        deleteTestIndex();
+
+        insertMockData(111);
+        insertMockData(112);
+        insertMockData(113);
+        insertMockData(114);
+        refreshIndex();
+
+        ElasticSourceTask task = new ElasticSourceTask(ElasticSourceConnectorConfig.AVRO_FIELD_CONVERTER);
+        Mockito.when(context.offsetStorageReader()).thenReturn(MockOffsetFactory.empty());
+        task.initialize(context);
+        Map<String, String> conf = getConf();
+        conf.put(ElasticSourceConnectorConfig.FIELDS_JSON_CAST_CONFIG, "fullName");
+
+        //when (fetching first page)
+        task.start(conf);
+        List<SourceRecord> poll1 = task.poll();
+        assertEquals("Struct{fullName=\"Test\",nonavrofield=non-avro-field,avroField=avro-field,age=10,ts=111}", poll1.get(0).value().toString());
+
+        task.stop();
+    }
+
+    @Test
+    public void shouldRunSourceTaskWithNopNameConverter() throws IOException, InterruptedException {
+        //given
+        deleteTestIndex();
+
+        insertMockData(111);
+        insertMockData(112);
+        insertMockData(113);
+        insertMockData(114);
+        refreshIndex();
+
+        ElasticSourceTask task = new ElasticSourceTask(ElasticSourceConnectorConfig.NOP_FIELD_CONVERTER);
+        Mockito.when(context.offsetStorageReader()).thenReturn(MockOffsetFactory.empty());
+        task.initialize(context);
+        Map<String, String> conf = getConf();
+        conf.put(ElasticSourceConnectorConfig.FIELDS_JSON_CAST_CONFIG, "fullName");
+
+        //when (fetching first page)
+        task.start(conf);
+        List<SourceRecord> poll1 = task.poll();
+        assertEquals("Struct{fullName=\"Test\",non-avro-field=non-avro-field,avroField=avro-field,age=10,ts=111}", poll1.get(0).value().toString());
+
+        task.stop();
+    }
+
+
+
 }

--- a/src/test/java/com/github/dariobalinzo/task/ElasticSourceTaskTest.java
+++ b/src/test/java/com/github/dariobalinzo/task/ElasticSourceTaskTest.java
@@ -166,7 +166,7 @@ public class ElasticSourceTaskTest extends TestContainersContext {
         insertMockData(114);
         refreshIndex();
 
-        ElasticSourceTask task = new ElasticSourceTask(ElasticSourceConnectorConfig.AVRO_FIELD_CONVERTER);
+        ElasticSourceTask task = new ElasticSourceTask();
         Mockito.when(context.offsetStorageReader()).thenReturn(MockOffsetFactory.empty());
         task.initialize(context);
         Map<String, String> conf = getConf();
@@ -191,11 +191,12 @@ public class ElasticSourceTaskTest extends TestContainersContext {
         insertMockData(114);
         refreshIndex();
 
-        ElasticSourceTask task = new ElasticSourceTask(ElasticSourceConnectorConfig.NOP_FIELD_CONVERTER);
+        ElasticSourceTask task = new ElasticSourceTask();
         Mockito.when(context.offsetStorageReader()).thenReturn(MockOffsetFactory.empty());
         task.initialize(context);
         Map<String, String> conf = getConf();
         conf.put(ElasticSourceConnectorConfig.FIELDS_JSON_CAST_CONFIG, "fullName");
+        conf.put(ElasticSourceConnectorConfig.CONNECTOR_FIELDNAME_CONVERTER_CONFIG, ElasticSourceConnectorConfig.NOP_FIELDNAME_CONVERTER);
 
         //when (fetching first page)
         task.start(conf);

--- a/src/test/java/com/github/dariobalinzo/task/ElasticSourceTaskTest.java
+++ b/src/test/java/com/github/dariobalinzo/task/ElasticSourceTaskTest.java
@@ -174,7 +174,7 @@ public class ElasticSourceTaskTest extends TestContainersContext {
         //when (fetching first page)
         task.start(conf);
         List<SourceRecord> poll1 = task.poll();
-        assertEquals("Struct{fullName=\"Test\",nonavrofield=non-avro-field,avroField=avro-field,age=10,ts=111}", poll1.get(0).value().toString());
+        assertEquals("Struct{fullName=Test,nonavrofield=non-avro-field,avroField=avro-field,age=10,ts=111}", poll1.get(0).value().toString());
 
         task.stop();
     }
@@ -199,7 +199,7 @@ public class ElasticSourceTaskTest extends TestContainersContext {
         //when (fetching first page)
         task.start(conf);
         List<SourceRecord> poll1 = task.poll();
-        assertEquals("Struct{fullName=\"Test\",non-avro-field=non-avro-field,avroField=avro-field,age=10,ts=111}", poll1.get(0).value().toString());
+        assertEquals("Struct{fullName=Test,non-avro-field=non-avro-field,avroField=avro-field,age=10,ts=111}", poll1.get(0).value().toString());
 
         task.stop();
     }

--- a/src/test/java/com/github/dariobalinzo/task/ElasticSourceTaskTest.java
+++ b/src/test/java/com/github/dariobalinzo/task/ElasticSourceTaskTest.java
@@ -170,7 +170,6 @@ public class ElasticSourceTaskTest extends TestContainersContext {
         Mockito.when(context.offsetStorageReader()).thenReturn(MockOffsetFactory.empty());
         task.initialize(context);
         Map<String, String> conf = getConf();
-        conf.put(ElasticSourceConnectorConfig.FIELDS_JSON_CAST_CONFIG, "fullName");
 
         //when (fetching first page)
         task.start(conf);
@@ -195,7 +194,6 @@ public class ElasticSourceTaskTest extends TestContainersContext {
         Mockito.when(context.offsetStorageReader()).thenReturn(MockOffsetFactory.empty());
         task.initialize(context);
         Map<String, String> conf = getConf();
-        conf.put(ElasticSourceConnectorConfig.FIELDS_JSON_CAST_CONFIG, "fullName");
         conf.put(ElasticSourceConnectorConfig.CONNECTOR_FIELDNAME_CONVERTER_CONFIG, ElasticSourceConnectorConfig.NOP_FIELDNAME_CONVERTER);
 
         //when (fetching first page)

--- a/src/test/java/com/github/dariobalinzo/task/ElasticSourceTaskTest.java
+++ b/src/test/java/com/github/dariobalinzo/task/ElasticSourceTaskTest.java
@@ -194,7 +194,8 @@ public class ElasticSourceTaskTest extends TestContainersContext {
         Mockito.when(context.offsetStorageReader()).thenReturn(MockOffsetFactory.empty());
         task.initialize(context);
         Map<String, String> conf = getConf();
-        conf.put(ElasticSourceConnectorConfig.CONNECTOR_FIELDNAME_CONVERTER_CONFIG, ElasticSourceConnectorConfig.NOP_FIELDNAME_CONVERTER);
+        conf.put(ElasticSourceConnectorConfig.CONNECTOR_FIELDNAME_CONVERTER_CONFIG,
+                ElasticSourceConnectorConfig.NOP_FIELDNAME_CONVERTER);
 
         //when (fetching first page)
         task.start(conf);
@@ -203,7 +204,6 @@ public class ElasticSourceTaskTest extends TestContainersContext {
 
         task.stop();
     }
-
 
 
 }


### PR DESCRIPTION
Make Field Name Converter configurable. Actually the fields are all converted in order to be "avro compliant". With this PR user will have the ability to choose the converter he wants to use. 

Avro converter will be the standard converter anyway..