### PR TITLE
fixed blacklist filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,14 +85,14 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-core</artifactId>
+            <version>4.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.0</version>
+            <version>2.13.2.2</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/github/dariobalinzo/ElasticSourceConnector.java
+++ b/src/main/java/com/github/dariobalinzo/ElasticSourceConnector.java
@@ -123,7 +123,6 @@ public class ElasticSourceConnector extends SourceConnector {
     }
 
     private List<Map<String, String>> generateTaskFromFixedList(List<String> indicesList, int maxTasks) {
-        int numGroups = Math.min(indicesList.size(), maxTasks);
         return groupIndicesToTasksConfig(maxTasks, indicesList);
     }
 

--- a/src/main/java/com/github/dariobalinzo/filter/BlacklistFilter.java
+++ b/src/main/java/com/github/dariobalinzo/filter/BlacklistFilter.java
@@ -31,8 +31,8 @@ public class BlacklistFilter implements DocumentFilter {
     private Object filterBlacklistItem(String key, Object value) {
         if (value instanceof Map || value instanceof List) {
             boolean shouldVisitNestedObj = fieldsToRemove.stream()
-                    .anyMatch(jsonPath -> jsonPath.startsWith(key));
-            return shouldVisitNestedObj ? value : null;
+                    .anyMatch(jsonPath -> key.startsWith(jsonPath));
+            return shouldVisitNestedObj ? null : value;
         }
         return fieldsToRemove.contains(key) ? null : value;
     }

--- a/src/test/java/com/github/dariobalinzo/filter/BlacklistFilterTest.java
+++ b/src/test/java/com/github/dariobalinzo/filter/BlacklistFilterTest.java
@@ -34,6 +34,8 @@ import java.util.stream.Stream;
 import static junit.framework.TestCase.assertEquals;
 
 public class BlacklistFilterTest {
+    private static final boolean IS_WINDOWS = System.getProperty( "os.name" ).contains( "indow" );
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
@@ -65,17 +67,19 @@ public class BlacklistFilterTest {
         String file = this.getClass().getClassLoader()
                 .getResource("com/github/dariobalinzo/filter/document.json")
                 .getFile();
-        String jsonDocument = new String(Files.readAllBytes(Paths.get(file)));
+        String osAppropriateFilePath = IS_WINDOWS ? file.substring(1) : file;
+        String jsonDocument = new String(Files.readAllBytes(Paths.get(osAppropriateFilePath)));
 
         Map<String, Object> elasticDocument = objectMapper.readValue(jsonDocument, Map.class);
 
         //when
-        Set<String> whitelist = Stream.of(
+        Set<String> blacklist = Stream.of(
                 "name",
                 "obj.details.qty",
-                "order_list.details.qty"
+                "order_list.details.qty",
+                "other-obj"
         ).collect(Collectors.toSet());
-        BlacklistFilter BlacklistFilter = new BlacklistFilter(whitelist);
+        BlacklistFilter BlacklistFilter = new BlacklistFilter(blacklist);
         BlacklistFilter.filter(elasticDocument);
 
         //then

--- a/src/test/java/com/github/dariobalinzo/filter/JsonCastFilterTest.java
+++ b/src/test/java/com/github/dariobalinzo/filter/JsonCastFilterTest.java
@@ -32,9 +32,10 @@ import java.util.stream.Stream;
 import static junit.framework.TestCase.assertEquals;
 
 public class JsonCastFilterTest {
+    private static final boolean IS_WINDOWS = System.getProperty( "os.name" ).contains( "indow" );
 
     private final ObjectMapper objectMapper = new ObjectMapper();
-
+    
     @SuppressWarnings("unchecked")
     @Test
     public void shouldConvertSimpleDocument() throws IOException {
@@ -42,7 +43,8 @@ public class JsonCastFilterTest {
         String file = this.getClass().getClassLoader()
                 .getResource("com/github/dariobalinzo/filter/document.json")
                 .getFile();
-        String jsonDocument = new String(Files.readAllBytes(Paths.get(file)));
+        String osAppropriateFilePath = IS_WINDOWS ? file.substring(1) : file;
+        String jsonDocument = new String(Files.readAllBytes(Paths.get(osAppropriateFilePath)));
 
         Map<String, Object> elasticDocument = objectMapper.readValue(jsonDocument, Map.class);
 

--- a/src/test/java/com/github/dariobalinzo/filter/WhitelistFilterTest.java
+++ b/src/test/java/com/github/dariobalinzo/filter/WhitelistFilterTest.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 import static junit.framework.TestCase.assertEquals;
 
 public class WhitelistFilterTest {
+    private static final boolean IS_WINDOWS = System.getProperty( "os.name" ).contains( "indow" );
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
@@ -65,7 +66,8 @@ public class WhitelistFilterTest {
         String file = this.getClass().getClassLoader()
                 .getResource("com/github/dariobalinzo/filter/document.json")
                 .getFile();
-        String jsonDocument = new String(Files.readAllBytes(Paths.get(file)));
+        String osAppropriateFilePath = IS_WINDOWS ? file.substring(1) : file;
+        String jsonDocument = new String(Files.readAllBytes(Paths.get(osAppropriateFilePath)));
 
         Map<String, Object> elasticDocument = objectMapper.readValue(jsonDocument, Map.class);
 

--- a/src/test/java/com/github/dariobalinzo/schema/SchemaConverterTest.java
+++ b/src/test/java/com/github/dariobalinzo/schema/SchemaConverterTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Paths;
 import java.util.*;
 
 public class SchemaConverterTest {
+    private static final boolean IS_WINDOWS = System.getProperty( "os.name" ).contains( "indow" );
 
     private final SchemaConverter schemaConverter = new SchemaConverter(new AvroName());
     private final StructConverter structConverter = new StructConverter(new AvroName());
@@ -183,7 +184,8 @@ public class SchemaConverterTest {
         String file = this.getClass().getClassLoader()
                 .getResource("com/github/dariobalinzo/schema/complexDocument.json")
                 .getFile();
-        String jsonDocument = new String(Files.readAllBytes(Paths.get(file)));
+        String osAppropriateFilePath = IS_WINDOWS ? file.substring(1) : file;
+        String jsonDocument = new String(Files.readAllBytes(Paths.get(osAppropriateFilePath)));
 
         Map<String, Object> elasticDocument = objectMapper.readValue(jsonDocument, Map.class);
 


### PR DESCRIPTION
Upgrade the jackson-databind to 2.13.2.2 since 2.13.0.0 is vulnerable to a Denial of Service [DoS] attack.
https://github.com/FasterXML/jackson-databind/issues/3426

Fixed blacklist filtering:
 1. It should return null (but not the value) for list/map if key is in the blacklist
 2. It should filter out (but not visit the nested value) the whole map/list if the key of map is in the blacklist