### PR TITLE
parse nested fields from cursor field value

### DIFF
--- a/src/main/java/com/github/dariobalinzo/elastic/CursorField.java
+++ b/src/main/java/com/github/dariobalinzo/elastic/CursorField.java
@@ -1,0 +1,35 @@
+package com.github.dariobalinzo.elastic;
+
+import java.util.Map;
+
+import static com.github.dariobalinzo.elastic.ElasticJsonNaming.removeKeywordSuffix;
+
+public class CursorField {
+    private final String cursor;
+
+    public CursorField(String cursor) {
+        this.cursor = removeKeywordSuffix(cursor);
+    }
+
+    public String read(Map<String, Object> document) {
+        return read(document, cursor);
+    }
+
+    private String read(Map<String, Object> document, String field) {
+        int firstDot = field.indexOf('.');
+
+        Object value = null;
+        if (document.containsKey(field)) {
+            value = document.get(field);
+        } else if (firstDot > 0 && firstDot < field.length() - 1) {
+            String parent = field.substring(0, firstDot);
+            Object nested = document.get(parent);
+            if (nested instanceof Map) {
+                return read((Map<String, Object>) document.get(parent),
+                            field.substring(firstDot + 1));
+            }
+        }
+
+        return value == null ? null : value.toString();
+    }
+}

--- a/src/main/java/com/github/dariobalinzo/elastic/ElasticRepository.java
+++ b/src/main/java/com/github/dariobalinzo/elastic/ElasticRepository.java
@@ -63,7 +63,7 @@ public final class ElasticRepository {
         this.cursorSearchField = cursorSearchField;
         this.cursorField = new CursorField(cursorSearchField);
         this.secondaryCursorSearchField = secondaryCursorSearchField;
-        this.secondaryCursorField = new CursorField(secondaryCursorSearchField);
+        this.secondaryCursorField = secondaryCursorSearchField == null ? null : new CursorField(secondaryCursorSearchField);
     }
 
     public PageResult searchAfter(String index, Cursor cursor) throws IOException, InterruptedException {
@@ -131,7 +131,7 @@ public final class ElasticRepository {
         } else {
             Map<String, Object> lastDocument = documents.get(documents.size() - 1);
             String primaryCursorValue = cursorField.read(lastDocument);
-            String secondaryCursorValue = cursorField.read(lastDocument);
+            String secondaryCursorValue = secondaryCursorField.read(lastDocument);
             lastCursor = new Cursor(primaryCursorValue, secondaryCursorValue);
         }
         return new PageResult(index, documents, lastCursor);

--- a/src/main/java/com/github/dariobalinzo/task/ElasticSourceTask.java
+++ b/src/main/java/com/github/dariobalinzo/task/ElasticSourceTask.java
@@ -97,7 +97,7 @@ public class ElasticSourceTask extends SourceTask {
                                                   + " conf is mandatory");
         cursorField = new CursorField(cursorSearchField);
         secondaryCursorSearchField = config.getString(ElasticSourceConnectorConfig.SECONDARY_INCREMENTING_FIELD_NAME_CONFIG);
-        secondaryCursorField = new CursorField(secondaryCursorSearchField);
+        secondaryCursorField = secondaryCursorSearchField == null ? null : new CursorField(secondaryCursorSearchField);
         pollingMs = Integer.parseInt(config.getString(ElasticSourceConnectorConfig.POLL_INTERVAL_MS_CONFIG));
 
         initConnectorFilters();

--- a/src/main/java/com/github/dariobalinzo/task/OffsetSerializer.java
+++ b/src/main/java/com/github/dariobalinzo/task/OffsetSerializer.java
@@ -1,5 +1,7 @@
 package com.github.dariobalinzo.task;
 
+import com.github.dariobalinzo.elastic.CursorField;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -8,7 +10,7 @@ import static com.github.dariobalinzo.task.ElasticSourceTask.POSITION_SECONDARY;
 
 public class OffsetSerializer {
 
-    public Map<String, String> toMapOffset(String primaryCursor, String secondaryCursor, Map<String, Object> document) {
+    public Map<String, String> toMapOffset(CursorField primaryCursor, CursorField secondaryCursor, Map<String, Object> document) {
         Map<String, String> result = new HashMap<>();
         result.put(POSITION, document.get(primaryCursor).toString());
         if (secondaryCursor != null) {
@@ -17,12 +19,12 @@ public class OffsetSerializer {
         return result;
     }
 
-    public String toStringOffset(String cursor, String secondaryCursor, String index, Map<String, Object> document) {
-        String cursorValue = document.get(cursor).toString();
+    public String toStringOffset(CursorField cursor, CursorField secondaryCursor, String index, Map<String, Object> document) {
+        String cursorValue = cursor.read(document);
         if (secondaryCursor == null) {
             return String.join("_", index, cursorValue);
         } else {
-            return String.join("_", index, cursorValue, document.get(secondaryCursor).toString());
+            return String.join("_", index, cursorValue, secondaryCursor.read(document));
         }
     }
 }

--- a/src/main/java/com/github/dariobalinzo/task/OffsetSerializer.java
+++ b/src/main/java/com/github/dariobalinzo/task/OffsetSerializer.java
@@ -12,9 +12,9 @@ public class OffsetSerializer {
 
     public Map<String, String> toMapOffset(CursorField primaryCursor, CursorField secondaryCursor, Map<String, Object> document) {
         Map<String, String> result = new HashMap<>();
-        result.put(POSITION, document.get(primaryCursor).toString());
+        result.put(POSITION, primaryCursor.read(document));
         if (secondaryCursor != null) {
-            result.put(POSITION_SECONDARY, document.get(secondaryCursor).toString());
+            result.put(POSITION_SECONDARY, secondaryCursor.read(document));
         }
         return result;
     }

--- a/src/test/java/com/github/dariobalinzo/TestContainersContext.java
+++ b/src/test/java/com/github/dariobalinzo/TestContainersContext.java
@@ -45,6 +45,8 @@ public class TestContainersContext {
 
     protected static final String TEST_INDEX = "source_index";
     protected static final String CURSOR_FIELD = "ts";
+    protected static final String NESTED_OBJECT = "nested";
+    protected static final String NESTED_CURSOR_FIELD = NESTED_OBJECT + "." + CURSOR_FIELD;
     protected static final String SECONDARY_CURSOR_FIELD = "fullName.keyword";
 
     protected static final String ELASTICSEARCH_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:7.11.1";
@@ -52,6 +54,7 @@ public class TestContainersContext {
     protected static ElasticsearchContainer container;
     protected static ElasticConnection connection;
     protected static ElasticRepository repository;
+    protected static ElasticRepository nestedRepository;
     protected static ElasticRepository secondarySortRepo;
 
     @BeforeClass
@@ -69,6 +72,9 @@ public class TestContainersContext {
 
         repository = new ElasticRepository(connection, CURSOR_FIELD);
         repository.setPageSize(TEST_PAGE_SIZE);
+
+        nestedRepository = new ElasticRepository(connection, NESTED_CURSOR_FIELD);
+        nestedRepository.setPageSize(TEST_PAGE_SIZE);
 
         secondarySortRepo = new ElasticRepository(connection, CURSOR_FIELD, SECONDARY_CURSOR_FIELD);
         secondarySortRepo.setPageSize(TEST_PAGE_SIZE);
@@ -103,6 +109,7 @@ public class TestContainersContext {
                 .field("age", 10)
                 .field("non-avro-field", "non-avro-field")
                 .field("avroField", "avro-field")
+                .object(NESTED_OBJECT, b -> b.field(CURSOR_FIELD, tsStart))
                 .endObject();
 
         IndexRequest indexRequest = new IndexRequest(index);

--- a/src/test/java/com/github/dariobalinzo/elastic/ElasticRepositoryTest.java
+++ b/src/test/java/com/github/dariobalinzo/elastic/ElasticRepositoryTest.java
@@ -52,6 +52,29 @@ public class ElasticRepositoryTest extends TestContainersContext {
         assertEquals(Collections.singletonList(TEST_INDEX), repository.catIndices("source"));
         assertEquals(Collections.emptyList(), repository.catIndices("non-existing"));
     }
+    @Test
+    public void shouldFetchDataFromElasticWithNestedCursor() throws IOException, InterruptedException {
+        deleteTestIndex();
+
+        insertMockData(111);
+        insertMockData(112);
+        insertMockData(113);
+        insertMockData(114);
+        refreshIndex();
+
+        PageResult firstPage = nestedRepository.searchAfter(TEST_INDEX, Cursor.empty());
+        assertEquals(3, firstPage.getDocuments().size());
+
+        PageResult secondPage = nestedRepository.searchAfter(TEST_INDEX, firstPage.getLastCursor());
+        assertEquals(1, secondPage.getDocuments().size());
+
+        PageResult emptyPage = nestedRepository.searchAfter(TEST_INDEX, secondPage.getLastCursor());
+        assertEquals(0, emptyPage.getDocuments().size());
+        assertNull(emptyPage.getLastCursor().getPrimaryCursor());
+
+        assertEquals(Collections.singletonList(TEST_INDEX), nestedRepository.catIndices("source"));
+        assertEquals(Collections.emptyList(), nestedRepository.catIndices("non-existing"));
+    }
 
     @Test
     public void shouldListExistingIndices() throws IOException, InterruptedException {


### PR DESCRIPTION
Hi,

I have documents in Elastic with the following structure:
```json
{
  "searchProps": {
    "latestUpdate": "2022-10-25T06:21:10.891414"
   }
  "document": {...}
}
```

I think that I am able to use your connector with the changes of this PR.

P.S. I think the default cursor field `_id` used in `ElasticRepository` is wrong, because you pass the document id in the document Map<String, Object> as `es-id`.