### PR TITLE
support deep unions in lists

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.15.0</version>
+            <version>2.28.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/github/dariobalinzo/schema/SchemaConverter.java
+++ b/src/main/java/com/github/dariobalinzo/schema/SchemaConverter.java
@@ -31,6 +31,8 @@ import static org.apache.kafka.connect.data.Schema.OPTIONAL_BOOLEAN_SCHEMA;
 import static org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA;
 import static org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA;
 import static org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA;
+import static org.apache.kafka.connect.data.Schema.Type.FLOAT64;
+import static org.apache.kafka.connect.data.Schema.Type.INT64;
 import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
 import static org.apache.kafka.connect.data.SchemaBuilder.array;
 import static org.apache.kafka.connect.data.SchemaBuilder.struct;
@@ -158,8 +160,12 @@ public class SchemaConverter {
 
     private Schema merge(Schema a, Schema b) {
         if (!(a.type() == STRUCT && b.type() == STRUCT)) {
-            // we can only merge structs, we therefor always return the first found schema
-            return a;
+            if(a.type() == INT64 && b.type() == FLOAT64) {
+                return b;
+            } else {
+                // we can only merge structs, we therefor always return the first found schema
+                return a;
+            }
         }
 
         Map<String, Schema> fieldsUnion = new LinkedHashMap<>();

--- a/src/main/java/com/github/dariobalinzo/schema/SchemaConverter.java
+++ b/src/main/java/com/github/dariobalinzo/schema/SchemaConverter.java
@@ -101,9 +101,11 @@ public class SchemaConverter {
     private void convertListSchema(String prefixName, SchemaBuilder schemaBuilder, String k, List<?> items) {
         String validKeyName = converter.from(k);
 
-        Set<Schema> schemas = items.stream().map(this::convertListSchema).collect(Collectors.toSet());
+        Set<Schema> schemas = items.stream().filter(i -> i != null).map(this::convertListSchema).collect(Collectors.toSet());
         Schema itemSchema;
-        if(schemas.size() == 1) {
+        if(schemas.isEmpty()) {
+            itemSchema = OPTIONAL_STRING_SCHEMA;
+        } else if(schemas.size() == 1) {
             itemSchema = schemas.iterator().next();
         } else if(!schemas.contains(OPTIONAL_STRING_SCHEMA) && !schemas.contains(OPTIONAL_BOOLEAN_SCHEMA)) {
             itemSchema = OPTIONAL_FLOAT64_SCHEMA;

--- a/src/main/java/com/github/dariobalinzo/schema/StructConverter.java
+++ b/src/main/java/com/github/dariobalinzo/schema/StructConverter.java
@@ -85,8 +85,10 @@ public class StructConverter {
 
         if (!value.isEmpty()) {
             //assuming that every item of the list has the same schema
-            Object head = value.get(0);
-            if (isScalar(head)) {
+            Object head = value.stream().filter(i -> i != null).findFirst().orElse(null);
+            if(head == null) {
+                struct.put(converter.from(key), value);
+            }  else if (isScalar(head)) {
                 boolean isFloat64 = struct.schema().field(converter.from(key)).schema().valueSchema().type().equals(FLOAT64);
                 List<Object> scalars = value.stream()
                         .map(s -> isFloat64 ? ((Number) s).doubleValue() : handleNumericPrecision(s))

--- a/src/main/java/com/github/dariobalinzo/schema/StructConverter.java
+++ b/src/main/java/com/github/dariobalinzo/schema/StructConverter.java
@@ -46,8 +46,14 @@ public class StructConverter {
             Object value = entry.getValue();
 
             if (isScalar(value)) {
-                value = handleNumericPrecision(value);
-                struct.put(converter.from(key), value);
+                String field = converter.from(key);
+                boolean isFloat = struct.schema().field(field).schema().type() == FLOAT64;
+                if(isFloat && value instanceof Number) {
+                    value = ((Number) value).doubleValue();
+                } else {
+                    value = handleNumericPrecision(value);
+                }
+                struct.put(field, value);
             } else if (value instanceof List) {
                 convertListToAvroArray(prefixName, struct, schema, entry);
             } else if (value instanceof Map) {

--- a/src/test/java/com/github/dariobalinzo/FooTest.java
+++ b/src/test/java/com/github/dariobalinzo/FooTest.java
@@ -1,0 +1,44 @@
+package com.github.dariobalinzo;
+
+import com.github.dariobalinzo.schema.AvroName;
+import com.github.dariobalinzo.schema.FieldNameConverter;
+import com.github.dariobalinzo.schema.NopNameConverter;
+import com.github.dariobalinzo.schema.SchemaConverter;
+import com.github.dariobalinzo.schema.StructConverter;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.Before;
+import org.junit.Test;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+
+public class FooTest {
+
+    private SchemaConverter schemaConverter;
+    private StructConverter structConverter;
+
+    Map<String, Object> elasticDocument;
+
+    @Before
+    public void setup() throws IOException {
+        FieldNameConverter fieldNameConverter = new NopNameConverter();
+        this.schemaConverter = new SchemaConverter(fieldNameConverter);
+        this.structConverter = new StructConverter(fieldNameConverter);
+
+        String doc = new String(Files.readAllBytes(Paths.get("src/test/java/com/github/dariobalinzo/foo.json")));
+        elasticDocument = new ObjectMapper().readValue(doc, Map.class);
+    }
+
+    @Test
+    public void foo() {
+
+        Schema schema = schemaConverter.convert(elasticDocument, "foo");
+        Struct struct = structConverter.convert(elasticDocument, schema);
+
+        System.out.println(struct);
+    }
+}

--- a/src/test/java/com/github/dariobalinzo/foo.json
+++ b/src/test/java/com/github/dariobalinzo/foo.json
@@ -1,0 +1,108 @@
+{
+  "equipments": [
+    {
+      "prices": {
+        "listPrice": {
+          "netPrice": {
+            "amount": 420.17,
+            "currency": "EUR"
+          },
+          "grossPrice": {
+            "amount": 500,
+            "currency": "EUR"
+          },
+          "updatedAt": "2023-05-17T04:08:18.046399"
+        },
+        "salesPrice": {
+          "netPrice": {
+            "amount": 0,
+            "currency": "EUR"
+          },
+          "grossPrice": {
+            "amount": 0,
+            "currency": "EUR"
+          },
+          "updatedAt": "2023-05-17T04:08:17.844466"
+        }
+      }
+    },
+    {
+      "prices": {
+        "listPrice": {
+          "netPrice": {
+            "amount": 0,
+            "currency": "EUR"
+          },
+          "grossPrice": {
+            "amount": 0,
+            "currency": "EUR"
+          },
+          "updatedAt": "2023-05-17T04:08:18.046401"
+        },
+        "salesPrice": {
+          "netPrice": {
+            "amount": 0,
+            "currency": "EUR"
+          },
+          "grossPrice": {
+            "amount": 0,
+            "currency": "EUR"
+          },
+          "updatedAt": "2023-05-17T04:08:17.844525"
+        }
+      }
+    },
+    {
+      "prices": {
+        "listPrice": {
+          "netPrice": {
+            "amount": 3403.36,
+            "currency": "EUR"
+          },
+          "grossPrice": {
+            "amount": 4050,
+            "currency": "EUR"
+          },
+          "updatedAt": "2023-05-17T04:08:18.0464"
+        },
+        "salesPrice": {
+          "netPrice": {
+            "amount": 0,
+            "currency": "EUR"
+          },
+          "grossPrice": {
+            "amount": 0,
+            "currency": "EUR"
+          },
+          "updatedAt": "2023-05-17T04:08:17.844519"
+        }
+      }
+    },
+    {
+      "prices": {
+        "listPrice": {
+          "netPrice": {
+            "amount": 0,
+            "currency": "EUR"
+          },
+          "grossPrice": {
+            "amount": 0,
+            "currency": "EUR"
+          },
+          "updatedAt": "2023-05-17T04:08:18.046397"
+        },
+        "salesPrice": {
+          "netPrice": {
+            "amount": 0,
+            "currency": "EUR"
+          },
+          "grossPrice": {
+            "amount": 0,
+            "currency": "EUR"
+          },
+          "updatedAt": "2023-05-17T04:08:17.844406"
+        }
+      }
+    }
+  ]
+}

--- a/src/test/java/com/github/dariobalinzo/schema/SchemaConverterTest.java
+++ b/src/test/java/com/github/dariobalinzo/schema/SchemaConverterTest.java
@@ -24,16 +24,77 @@ import org.apache.kafka.connect.data.Struct;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.ws.rs.core.Link;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
+
+import static org.apache.kafka.connect.data.SchemaBuilder.array;
+import static org.apache.kafka.connect.data.SchemaBuilder.string;
+import static org.apache.kafka.connect.data.SchemaBuilder.struct;
 
 public class SchemaConverterTest {
 
     private final SchemaConverter schemaConverter = new SchemaConverter(new AvroName());
     private final StructConverter structConverter = new StructConverter(new AvroName());
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void shouldConvertArrayWithDifferentSchema() {
+        //given
+        List<Map<String, Object>> list = new ArrayList<>();
+        Map<String, Object> variant1 = mapOf("inner", mapOf("a", "some value"));
+        Map<String, Object> variant2 = mapOf("inner", mapOf("b", "some value"));
+
+        list.add(variant1);
+        list.add(variant2);
+
+        Map<String, Object> elasticDocument = new LinkedHashMap<>();
+        elasticDocument.put("list", list);
+
+        //when
+        Schema schema = schemaConverter.convert(elasticDocument, "test");
+        Struct struct = structConverter.convert(elasticDocument, schema);
+
+        //then
+        Schema expected = struct().name("list.inner")
+                                  .optional()
+                                  .field("a", string().optional().build())
+                                  .field("b", string().optional().build())
+                                  .build();
+        Schema innerSchema = schema.field("list").schema().valueSchema().field("inner").schema().schema();
+        Assert.assertEquals(expected, innerSchema);
+        Assert.assertEquals("Struct{list=[Struct{inner=Struct{a=some value}}, Struct{inner=Struct{b=some value}}]}", struct.toString());
+    }
+    @Test
+    public void shouldConvertNormalListsWithoutMerging() {
+        //given
+        List<Map<String, Object>> list = new ArrayList<>();
+        Map<String, Object> variant1 = mapOf("inner", 3);
+        Map<String, Object> variant2 = mapOf("inner", 4);
+
+        list.add(variant1);
+        list.add(variant2);
+
+        Map<String, Object> elasticDocument = new LinkedHashMap<>();
+        elasticDocument.put("list", list);
+
+        //when
+        Schema schema = schemaConverter.convert(elasticDocument, "test");
+        Struct struct = structConverter.convert(elasticDocument, schema);
+
+        //then
+        Schema innerSchema = schema.field("list").schema().valueSchema().field("inner").schema().schema();
+        Assert.assertEquals("Schema{INT64}", innerSchema.toString());
+        Assert.assertEquals("Struct{list=[Struct{inner=3}, Struct{inner=4}]}", struct.toString());
+    }
+
+    private Map<String, Object> mapOf(String key, Object value) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put(key, value);
+        return map;
+    }
 
     @Test
     public void shouldConvertSimpleSchema() {
@@ -205,38 +266,38 @@ public class SchemaConverterTest {
                 "gpiopins=[" +
                 "Struct{pin=1,name=3.3v}, " +
                 "Struct{pin=2,name=5v}, " +
-                "Struct{mode=IN,pin=3,name=SDA.1,bcm=2,voltage=1}, " +
+                "Struct{pin=3,name=SDA.1,bcm=2,mode=IN,voltage=1}, " +
                 "Struct{pin=4,name=5v}, " +
-                "Struct{mode=IN,pin=5,name=SCL.1,bcm=3,voltage=1}, " +
-                "Struct{pin=6,name=0v}, Struct{mode=IN,pin=7,name=GPIO. 7,bcm=4,voltage=1}, " +
-                "Struct{mode=IN,pin=8,name=TxD,voltage=1}, Struct{pin=9,name=0v}, " +
-                "Struct{mode=IN,pin=10,name=RxD,voltage=1}, Struct{mode=IN,pin=11,name=GPIO. 0,bcm=17,voltage=0}, " +
-                "Struct{mode=IN,pin=12,name=GPIO. 1,voltage=0}, Struct{mode=IN,pin=13,name=GPIO. 2,bcm=27,voltage=0}, " +
-                "Struct{pin=14,name=0v}, Struct{mode=IN,pin=15,name=GPIO. 3,bcm=22,voltage=0}, " +
-                "Struct{mode=IN,pin=16,name=GPIO. 4,voltage=0}, " +
+                "Struct{pin=5,name=SCL.1,bcm=3,mode=IN,voltage=1}, " +
+                "Struct{pin=6,name=0v}, Struct{pin=7,name=GPIO. 7,bcm=4,mode=IN,voltage=1}, " +
+                "Struct{pin=8,name=TxD,mode=IN,voltage=1}, Struct{pin=9,name=0v}, " +
+                "Struct{pin=10,name=RxD,mode=IN,voltage=1}, Struct{pin=11,name=GPIO. 0,bcm=17,mode=IN,voltage=0}, " +
+                "Struct{pin=12,name=GPIO. 1,mode=IN,voltage=0}, Struct{pin=13,name=GPIO. 2,bcm=27,mode=IN,voltage=0}, " +
+                "Struct{pin=14,name=0v}, Struct{pin=15,name=GPIO. 3,bcm=22,mode=IN,voltage=0}, " +
+                "Struct{pin=16,name=GPIO. 4,mode=IN,voltage=0}, " +
                 "Struct{pin=17,name=3.3v}, " +
-                "Struct{mode=IN,pin=18,name=GPIO. 5,voltage=0}, " +
-                "Struct{mode=IN,pin=19,name=MOSI,bcm=10,voltage=0}, " +
-                "Struct{pin=20,name=0v}, Struct{mode=IN,pin=21,name=MISO,bcm=9,voltage=0}, " +
-                "Struct{mode=IN,pin=22,name=GPIO. 6,voltage=0}, " +
-                "Struct{mode=IN,pin=23,name=SCLK,bcm=11,voltage=0}, " +
-                "Struct{mode=IN,pin=24,name=CE0,voltage=1}, " +
+                "Struct{pin=18,name=GPIO. 5,mode=IN,voltage=0}, " +
+                "Struct{pin=19,name=MOSI,bcm=10,mode=IN,voltage=0}, " +
+                "Struct{pin=20,name=0v}, Struct{pin=21,name=MISO,bcm=9,mode=IN,voltage=0}, " +
+                "Struct{pin=22,name=GPIO. 6,mode=IN,voltage=0}, " +
+                "Struct{pin=23,name=SCLK,bcm=11,mode=IN,voltage=0}, " +
+                "Struct{pin=24,name=CE0,mode=IN,voltage=1}, " +
                 "Struct{pin=25,name=0v}, " +
-                "Struct{mode=IN,pin=26,name=CE1,voltage=1}, " +
-                "Struct{mode=IN,pin=27,name=SDA.0,bcm=0,voltage=1}, " +
-                "Struct{mode=IN,pin=28,name=SCL.0,voltage=1}, " +
-                "Struct{mode=IN,pin=29,name=GPIO.21,bcm=5,voltage=1}, " +
+                "Struct{pin=26,name=CE1,mode=IN,voltage=1}, " +
+                "Struct{pin=27,name=SDA.0,bcm=0,mode=IN,voltage=1}, " +
+                "Struct{pin=28,name=SCL.0,mode=IN,voltage=1}, " +
+                "Struct{pin=29,name=GPIO.21,bcm=5,mode=IN,voltage=1}, " +
                 "Struct{pin=30,name=0v}, " +
-                "Struct{mode=IN,pin=31,name=GPIO.22,bcm=6,voltage=1}, " +
-                "Struct{mode=IN,pin=32,name=GPIO.26,voltage=0}, " +
-                "Struct{mode=IN,pin=33,name=GPIO.23,bcm=13,voltage=0}, " +
+                "Struct{pin=31,name=GPIO.22,bcm=6,mode=IN,voltage=1}, " +
+                "Struct{pin=32,name=GPIO.26,mode=IN,voltage=0}, " +
+                "Struct{pin=33,name=GPIO.23,bcm=13,mode=IN,voltage=0}, " +
                 "Struct{pin=34,name=0v}, " +
-                "Struct{mode=IN,pin=35,name=GPIO.24,bcm=19,voltage=0}, " +
-                "Struct{mode=IN,pin=36,name=GPIO.27,voltage=0}, " +
-                "Struct{mode=IN,pin=37,name=GPIO.25,bcm=26,voltage=0}, " +
-                "Struct{mode=IN,pin=38,name=GPIO.28,voltage=0}, " +
+                "Struct{pin=35,name=GPIO.24,bcm=19,mode=IN,voltage=0}, " +
+                "Struct{pin=36,name=GPIO.27,mode=IN,voltage=0}, " +
+                "Struct{pin=37,name=GPIO.25,bcm=26,mode=IN,voltage=0}, " +
+                "Struct{pin=38,name=GPIO.28,mode=IN,voltage=0}, " +
                 "Struct{pin=39,name=0v}, " +
-                "Struct{mode=IN,pin=40,name=GPIO.29,voltage=0}" +
+                "Struct{pin=40,name=GPIO.29,mode=IN,voltage=0}" +
                 "]," +
                 "createdby=internal," +
                 "status=OPERATIONAL,id=xxx-status/b5054ecf-9f18-4b86-bc95-30933fe05581," +
@@ -260,35 +321,35 @@ public class SchemaConverterTest {
                 "topic=ram,rawsample={\"capacity\": 3828, \"used\": 1235},capacity=3828,used=1235}," +
                 "disks=[" +
                 "Struct{" +
-                "topic=disks," +
-                "rawsample={\"device\": \"overlay\", \"capacity\": 28, \"used\": 4}," +
-                "used=4," +
                 "device=overlay," +
-                "capacity=28" +
+                "capacity=28," +
+                "used=4," +
+                "topic=disks," +
+                "rawsample={\"device\": \"overlay\", \"capacity\": 28, \"used\": 4}" +
                 "}" +
                 "]," +
                 "netstats=[" +
                 "Struct{" +
+                "interface=docker_gwbridge," +
                 "bytestransmitted=1810018," +
-                "bytesreceived=633," +
-                "interface=docker_gwbridge" +
+                "bytesreceived=633" +
                 "}, " +
                 "Struct{" +
+                "interface=lo," +
                 "bytestransmitted=153116745," +
-                "bytesreceived=153116745," +
-                "interface=lo}, " +
-                "Struct{bytestransmitted=3865916,bytesreceived=1275,interface=veth53b9858}, " +
-                "Struct{bytestransmitted=4349209,bytesreceived=0,interface=vetha95aba6}, " +
-                "Struct{bytestransmitted=58162393,bytesreceived=1347447,interface=docker0}, " +
-                "Struct{bytestransmitted=20942074,bytesreceived=12350057,interface=veth2d9e5be}, " +
-                "Struct{bytestransmitted=723871,bytesreceived=352184,interface=vethe4e283e}, " +
-                "Struct{bytestransmitted=23136462,bytesreceived=61398287,interface=veth5207da0}, " +
-                "Struct{bytestransmitted=3858289,bytesreceived=689,interface=vethef962b3}, " +
-                "Struct{bytestransmitted=3936275,bytesreceived=7957,interface=vetha49fdcb}, " +
-                "Struct{bytestransmitted=145658655,bytesreceived=147435494,interface=br-193effb5470e}, " +
-                "Struct{bytestransmitted=91616660,bytesreceived=307622918,interface=wlan0}, " +
-                "Struct{bytestransmitted=25273385,bytesreceived=66929714,interface=veth3d6d8ed}, " +
-                "Struct{bytestransmitted=0,bytesreceived=0,interface=eth0}" +
+                "bytesreceived=153116745}, " +
+                "Struct{interface=veth53b9858,bytestransmitted=3865916,bytesreceived=1275}, " +
+                "Struct{interface=vetha95aba6,bytestransmitted=4349209,bytesreceived=0}, " +
+                "Struct{interface=docker0,bytestransmitted=58162393,bytesreceived=1347447}, " +
+                "Struct{interface=veth2d9e5be,bytestransmitted=20942074,bytesreceived=12350057}, " +
+                "Struct{interface=vethe4e283e,bytestransmitted=723871,bytesreceived=352184}, " +
+                "Struct{interface=veth5207da0,bytestransmitted=23136462,bytesreceived=61398287}, " +
+                "Struct{interface=vethef962b3,bytestransmitted=3858289,bytesreceived=689}, " +
+                "Struct{interface=vetha49fdcb,bytestransmitted=3936275,bytesreceived=7957}, " +
+                "Struct{interface=br-193effb5470e,bytestransmitted=145658655,bytesreceived=147435494}, " +
+                "Struct{interface=wlan0,bytestransmitted=91616660,bytesreceived=307622918}, " +
+                "Struct{interface=veth3d6d8ed,bytestransmitted=25273385,bytesreceived=66929714}, " +
+                "Struct{interface=eth0,bytestransmitted=0,bytesreceived=0}" +
                 "]}," +
                 "inferredlocation=[6.0826, 46.1443]," +
                 "vulnerabilities=Struct{" +

--- a/src/test/java/com/github/dariobalinzo/schema/SchemaConverterTest.java
+++ b/src/test/java/com/github/dariobalinzo/schema/SchemaConverterTest.java
@@ -400,6 +400,21 @@ public class SchemaConverterTest {
     }
 
     @Test
+    public void shouldUpcastNestedLongToFloatWhenAtLeastOnEntryIsFloat() {
+        Map<String, Object> elasticDocument = mapOf("foo", asList(
+                mapOf("bar", 1),
+                mapOf("bar", 3.0)
+        ));
+
+        Schema schema = schemaConverter.convert(elasticDocument, "test");
+        Struct struct = structConverter.convert(elasticDocument, schema);
+
+        Assert.assertEquals("Schema{FLOAT64}", schema.field("foo").schema().valueSchema()
+                                                     .field("bar").schema().toString());
+        Assert.assertEquals("Struct{foo=[Struct{bar=1.0}, Struct{bar=3.0}]}", struct.toString());
+    }
+
+    @Test
     public void shouldMergeByMarkingMergedFieldsAsOptional() {
         Map<String, Object> elasticDocument = mapOf("a", asList(emptyMap(), mapOf("b", asList(emptyMap()))));
 

--- a/src/test/java/com/github/dariobalinzo/schema/SchemaConverterTest.java
+++ b/src/test/java/com/github/dariobalinzo/schema/SchemaConverterTest.java
@@ -405,6 +405,30 @@ public class SchemaConverterTest {
 
         Schema schema = schemaConverter.convert(elasticDocument, "test");
         Struct struct = structConverter.convert(elasticDocument, schema);
+
+        Assert.assertEquals("Struct{a=[Struct{}, Struct{b=[Struct{}]}]}", struct.toString());
+    }
+
+    @Test
+    public void shouldIgnoreFirstListValueIfNull() {
+        Map<String, Object> elasticDocument = mapOf("a", asList(null, 3));
+
+        Schema schema = schemaConverter.convert(elasticDocument, "test");
+        Struct struct = structConverter.convert(elasticDocument, schema);
+
+        //Assert.assertEquals("Schema{FLOAT64}", schema.toString());
+        Assert.assertEquals("Struct{a=[null, 3]}", struct.toString());
+    }
+
+    @Test
+    public void shouldIgnoreListValuesIfAllNull() {
+        Map<String, Object> elasticDocument = mapOf("a", asList(null, null));
+
+        Schema schema = schemaConverter.convert(elasticDocument, "test");
+        Struct struct = structConverter.convert(elasticDocument, schema);
+
+        //Assert.assertEquals("Schema{FLOAT64}", schema.toString());
+        Assert.assertEquals("Struct{a=[null, null]}", struct.toString());
     }
 
     private static class NotSupported {


### PR DESCRIPTION
I noticed that you merge the schemas of maps in lists.

So that for example the document
```json
{
  "list": [
    {"a": "some value"},
    {"b": "other value"},
  ]
}
```

creates an inner schema where `a` and `b` are optional.

I noticed with some of my data that this is not done recursivly, for example this document does not work currently
```json
{
  "list": [
    {"inner": {"a": "some value"}},
    {"inner": {"b": "other value"}},
  ]
}
```

This PR "fixes" this.