### PR TITLE
always return indicies in same order

### DIFF
--- a/src/main/java/com/github/dariobalinzo/elastic/ElasticRepository.java
+++ b/src/main/java/com/github/dariobalinzo/elastic/ElasticRepository.java
@@ -185,7 +185,6 @@ public final class ElasticRepository {
     public List<String> catIndices(String prefix) {
         Response resp;
         try {
-
             resp = elasticConnection.getClient()
                     .getLowLevelClient()
                     .performRequest(new Request("GET", "/_cat/indices"));
@@ -207,6 +206,8 @@ public final class ElasticRepository {
         } catch (IOException e) {
             logger.error("error while getting indices", e);
         }
+
+        Collections.sort(result);
 
         return result;
     }


### PR DESCRIPTION
While using an index prefix which resolved to many indicies I encountered the following problem:
- the ElasticRepository calls the `/_cat/indices`
- the returned index array is not stable (ordering is not fixed)
- tasks are created by splitting this list
- when ordering of list changes => task configs changes
- when task config changes => tasks are stopped and started again
- the index list is updated every few seconds

